### PR TITLE
Update ks_spaces_validator.py

### DIFF
--- a/fuel_agent/drivers/ks_spaces_validator.py
+++ b/fuel_agent/drivers/ks_spaces_validator.py
@@ -140,10 +140,16 @@ def validate(scheme):
             'Partition scheme seems empty')
 
     for space in scheme:
+        rootcount = 0
         for volume in space.get('volumes', []):
             if volume['size'] > 16777216 and volume['mount'] == '/':
                 raise errors.WrongPartitionSchemeError(
                     'Root file system must be less than 16T')
+            if volume['mount'] == '/':
+                rootcount += 1
+        if rootcount > 1:
+            raise errors.WrongPartitionSchemeError(
+                    'Multiple root partitions')
 
     # TODO(kozhukalov): need to have additional logical verifications
     # maybe sizes and format of string values


### PR DESCRIPTION
There should be only one root. Errors elsewhere resulted in our cinder volume getting caught here at the 16T check, this would have made the error message more descriptive.
