### PR TITLE
Update test_hardware_utils.py

### DIFF
--- a/fuel_agent/tests/test_hardware_utils.py
+++ b/fuel_agent/tests/test_hardware_utils.py
@@ -328,7 +328,7 @@ supports-register-dump: yes
         # look at kernel/Documentation/devices.txt
         mock_breport.return_value = {}
         valid_majors = [3, 8, 9, 65, 66, 67, 68, 69, 70, 71, 104, 105,
-                        106, 107, 108, 109, 110, 111, 202, 252, 253, 259]
+                        106, 107, 108, 109, 110, 111, 202, 251, 252, 253, 259]
         for major in (set(range(1, 261)) - set(valid_majors)):
             uspec = {
                 'MAJOR': str(major)


### PR DESCRIPTION
Update VALID_MAJORS to include 251, the device number of Sandisk FusionIO SX300 drives.
